### PR TITLE
option to cancel friend request (fixes #19)

### DIFF
--- a/app/src/main/java/com/magnitudestudios/GameFace/repository/FirebaseHelper.kt
+++ b/app/src/main/java/com/magnitudestudios/GameFace/repository/FirebaseHelper.kt
@@ -202,14 +202,14 @@ object FirebaseHelper {
                 )
     }
 
-    suspend fun deleteFriendRequest(uid: String) {
+    suspend fun deleteFriendRequest(uid: String, gotFriendRequest: Boolean) {
         getCurrentUserRef()
-                .child(User::friendRequests.name)
+                .child(if (gotFriendRequest) User::friendRequests.name else User::friendRequestsSent.name)
                 .child(uid)
                 .removeValue().await()
 
         getUserRef(uid)
-                .child(User::friendRequestsSent.name)
+                .child(if (gotFriendRequest) User::friendRequestsSent.name else User::friendRequests.name)
                 .child(Firebase.auth.currentUser!!.uid)
                 .removeValue().await()
     }
@@ -223,7 +223,7 @@ object FirebaseHelper {
                 .child(User::friends.name)
                 .child(Firebase.auth.currentUser!!.uid)
                 .setValue(Friend(Firebase.auth.currentUser!!.uid))
-        deleteFriendRequest(uid)
+        deleteFriendRequest(uid, true)
     }
 
 }

--- a/app/src/main/java/com/magnitudestudios/GameFace/ui/addFriends/AddFriendsFragment.kt
+++ b/app/src/main/java/com/magnitudestudios/GameFace/ui/addFriends/AddFriendsFragment.kt
@@ -94,6 +94,7 @@ class AddFriendsFragment : Fragment() {
                     override fun onClick(position: Int) {
                         val clicked = addAdapter.getitem(position)
                         if (getHolderState(clicked.uid) == Constants.STATE_DEFAULT) viewModel.sendFriendRequest(clicked)
+                        else if (getHolderState(clicked.uid) == Constants.STATE_REQUESTED) viewModel.deleteFriendRequest(clicked)
                     }
                     override fun onLongClick(position: Int) {}
 

--- a/app/src/main/java/com/magnitudestudios/GameFace/ui/addFriends/AddFriendsViewModel.kt
+++ b/app/src/main/java/com/magnitudestudios/GameFace/ui/addFriends/AddFriendsViewModel.kt
@@ -7,6 +7,7 @@
 
 package com.magnitudestudios.GameFace.ui.addFriends
 
+import android.util.Log
 import androidx.lifecycle.*
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
@@ -15,6 +16,7 @@ import com.magnitudestudios.GameFace.pojo.UserInfo.FriendRequest
 import com.magnitudestudios.GameFace.pojo.UserInfo.Profile
 import com.magnitudestudios.GameFace.repository.FirebaseHelper
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class AddFriendsViewModel : ViewModel() {
     private val queryString: MutableLiveData<String> = MutableLiveData()
@@ -45,6 +47,16 @@ class AddFriendsViewModel : ViewModel() {
 
     fun sendFriendRequest(profile: Profile) {
         if (profile.uid != Firebase.auth.currentUser!!.uid) FirebaseHelper.sendFriendRequest(profile)
+    }
+
+    fun deleteFriendRequest(profile: Profile) {
+        Log.e("HERE", "FIRST")
+        if (profile.uid in getFriendRequestedUIDs()) {
+            Log.e("HERE", "SECOND")
+            viewModelScope.launch(Dispatchers.IO) {
+                FirebaseHelper.deleteFriendRequest(profile.uid, false)
+            }
+        }
     }
 
     fun getFriendRequestedUIDs() : List<String> {

--- a/app/src/main/java/com/magnitudestudios/GameFace/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/magnitudestudios/GameFace/ui/profile/ProfileViewModel.kt
@@ -48,7 +48,7 @@ class ProfileViewModel : ViewModel() {
 
     fun denyFriendRequest(uid: String) {
         viewModelScope.launch(Dispatchers.IO) {
-            FirebaseHelper.deleteFriendRequest(uid)
+            FirebaseHelper.deleteFriendRequest(uid, true)
         }
     }
 }


### PR DESCRIPTION
# Fixes #19 
- Should be able to cancel friend requests now
- Make sure that works and that the delete button on the FriendRequests page is still working